### PR TITLE
fix: Google Calendar duplicates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "my-itmo-ru-to-ical"
-version = "1.0.0"
+version = "1.1.0"
 description = "A simple app exporting the scheudle from my.itmo.ru in iCalendar format."
 authors = ["iburakov <speedwatson@gmail.com>"]
 license = "MIT"

--- a/src/lessons_to_events.py
+++ b/src/lessons_to_events.py
@@ -54,9 +54,9 @@ def _raw_lesson_to_location(raw_lesson: dict):
 
 def _raw_lesson_to_uuid(raw_lesson: dict):
     elements = [
-        raw_lesson['date'],
-        raw_lesson['time_start'],
-        raw_lesson['subject']
+        raw_lesson["date"],
+        raw_lesson["time_start"],
+        raw_lesson["subject"],
     ]
     result = ", ".join(elements)
     md5_of_lesson = md5(result.encode("utf-8")).hexdigest()

--- a/src/lessons_to_events.py
+++ b/src/lessons_to_events.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta
+from hashlib import md5
+from uuid import UUID
 
 from dateutil.parser import isoparse
 from ics import Event
@@ -50,6 +52,18 @@ def _raw_lesson_to_location(raw_lesson: dict):
     return result if result else None
 
 
+def _raw_lesson_to_uuid(raw_lesson: dict):
+    elements = [
+        raw_lesson['date'],
+        raw_lesson['time_start'],
+        raw_lesson['subject']
+    ]
+    result = ", ".join(elements)
+    md5_of_lesson = md5(result.encode("utf-8")).hexdigest()
+    result_uuid = str(UUID(hex=md5_of_lesson))
+    return result_uuid
+
+
 def raw_lesson_to_event(raw_lesson: dict) -> Event:
     begin = isoparse(f"{raw_lesson['date']}T{raw_lesson['time_start']}:00+03:00")
     end = isoparse(f"{raw_lesson['date']}T{raw_lesson['time_end']}:00+03:00")
@@ -62,6 +76,7 @@ def raw_lesson_to_event(raw_lesson: dict) -> Event:
         end=end,
         description=_raw_lesson_to_description(raw_lesson),
         location=_raw_lesson_to_location(raw_lesson),
+        uid=_raw_lesson_to_uuid(raw_lesson),
     )
     if raw_lesson["zoom_url"]:
         event.url = raw_lesson["zoom_url"]


### PR DESCRIPTION
Добрый день!

Я столкнулся с такой проблемой, что при синхронизации этого сервиса с Гугл Календарем у меня дублировались занятия.
<details><summary>Пример</summary>

![caldupes](https://github.com/user-attachments/assets/12089c6f-8613-4a96-8c98-6749c51c89cb)
</details>

Предположительно, это происходит из-за получения занятия с новым UID, аналогичного уже существующему, но так как UID другой - они ставятся в одно и то же время.

Поэтому я добавил генерацию UID занятия на основе даты и времени занятия и его названия. Теперь при генерации календаря каждое занятие имеет фиксированный UID.

Проверено на своем аккаунте ИТМО. С версией из репозитория в течение суток происходит дублирование. С моими изменениями занятия остаются уникальными.  
> В идеале подождать еще с недельку, чтобы сервер с сервисом побывал в различных состояниях и гипотеза с UID подтвердилась. Я открываю МР заранее, чтобы была возможность обсудить проблему и взглянуть с разных сторон

> Мини-дисклеймер: я не уверен в самой основе проблемы. Возможно, это связано с подтормаживанием сервера, и не проявляется на стабильных машинах. Возможно, это связано с чем-то другим, не с UID. Однако, установка UID решает проблему, дублирование не происходит
