### PR TITLE
Fix/auth: Fix auth issue due to form auth regex invalidation

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -29,7 +29,7 @@ def get_code_challenge(code_verifier: str):
     return code_challenge.replace("=", "")  # remove base64 padding
 
 
-_FORM_ACTION_REGEX = re.compile(r'"registrationAction":\s*"(?P<action>https://id\.itmo\.ru/auth/realms/itmo/login-actions/authenticate\?[^"]*)"', re.DOTALL)
+_FORM_ACTION_REGEX = re.compile(rf'"loginAction":\s*"(?P<action>{re.escape(_PROVIDER)}[^"]*)"', re.DOTALL)
 
 
 @AsyncTTL(time_to_live=55 * 60, skip_args=1)

--- a/src/auth.py
+++ b/src/auth.py
@@ -29,7 +29,7 @@ def get_code_challenge(code_verifier: str):
     return code_challenge.replace("=", "")  # remove base64 padding
 
 
-_FORM_ACTION_REGEX = re.compile(r'<form\s+.*?\s+action="(?P<action>.*?)"', re.DOTALL)
+_FORM_ACTION_REGEX = re.compile(r'"registrationAction":\s*"(?P<action>https://id\.itmo\.ru/auth/realms/itmo/login-actions/authenticate\?[^"]*)"', re.DOTALL)
 
 
 @AsyncTTL(time_to_live=55 * 60, skip_args=1)


### PR DESCRIPTION
Since the itmo environment has changed, therefore, the url for the action
has changed, the new regex receives this url, which solves the problem with authorization

closes #10